### PR TITLE
chore: add Kubewarden repository badges.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Stable](https://img.shields.io/badge/status-stable-brightgreen?style=for-the-badge)](https://github.com/kubewarden/community/blob/main/REPOSITORIES.md#stable)
+
 # RFC
 
 This repository contains all RFCs for the Kubewarden project.


### PR DESCRIPTION
## Description

Adds the Kubewarden repository badges document the scope and status of the repository in the Kubewarden ecosystem.

Related to https://github.com/kubewarden/kubewarden-controller/issues/727